### PR TITLE
Share PID namespace to fix SHMEM communication

### DIFF
--- a/intra_pod_shmem/README.md
+++ b/intra_pod_shmem/README.md
@@ -4,7 +4,7 @@
 You want to make Connext containers communicate over shared memory.
 
 ### Solution
-Containers in a pod share the same IPC namespace, which means they can communicate with each other using standard inter-process communications such as SystemV semaphores or POSIX shared memory. If containers are in the same pod, Connext containers with a version above 6.0 can communicate over shared memory with the default settings. (Please see [this](https://community.rti.com/kb/communicate-between-two-docker-containers-using-rti-connext-dds-and-shared-memory) if you use an older version.) A Connext container can use both shared memory transport for container-to-container communications (in the same pod) and UDP transport for pod-to-pod communications. 
+Containers in a pod share the same IPC namespace, which means they can communicate with each other using standard inter-process communications such as SystemV semaphores or POSIX shared memory. If containers are in the same pod and are also configured to share the same process namespace, Connext containers with a version above 6.0 can communicate over shared memory with the default settings. (Please see [this](https://community.rti.com/kb/communicate-between-two-docker-containers-using-rti-connext-dds-and-shared-memory) if you use an older version.) A Connext container can use both shared memory transport for container-to-container communications (in the same pod) and UDP transport for pod-to-pod communications.
 
 ![Container Communications over Shared Memory](ddsping_shmem.png)
 

--- a/intra_pod_shmem/rtiddsping_shmem.yaml
+++ b/intra_pod_shmem/rtiddsping_shmem.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: rtiddsping
     spec:
+      # Connext containers must share the PID namespace for SHMEM communication
+      shareProcessNamespace: true
       containers:
         - name: rtiddsping-pub
           image: rticom/dds-ping:7.3.0-EAR


### PR DESCRIPTION
For containers to be able to communicate over SHMEM they must share the same PID namespace as explained in the KB "[Communicate between two Docker containers using RTI Connext DDS and shared memory](https://community.rti.com/kb/communicate-between-two-docker-containers-using-rti-connext-dds-and-shared-memory#docs-internal-guid-8e1cf362-7fff-8b05-5e91-f18decb49bc0)". This is due to how Connext detects if a shmem segment can be reused.

If PID namespace is not shared, the participant might try to reuse a segment that is already in use by different participant. Thus both participants will end up with the same participant_id, which is undefined behavior.

In Connext >7.4.0 communication won't even work and you will face the following periodic warnings:
```
WARNING [0x01012101,0x06200367,0x9571CBF0:0x000100C2|DP ANNOUNCE|SEND] RTIOsapiSharedMemorySemMutex_attach_os:FAILED TO ATTACH | Semaphore set identifier 0x0 has not been initialized. Consider cleaning this semaphore if this warning occurs multiple times for this semaphore across all applications on this machine.
WARNING [0x01012101,0x06200367,0x9571CBF0:0x000100C2|DP ANNOUNCE|SEND] RTIOsapiSharedMemorySemMutex_attach_os:FAILED TO ATTACH | Semaphore set identifier 0x0 has not been initialized. Consider cleaning this semaphore if this warning occurs multiple times for this semaphore across all applications on this machine.
WARNING [0x01012101,0x06200367,0x9571CBF0:0x000100C2|DP ANNOUNCE|SEND] RTIOsapiSharedMemorySemMutex_attach_os:FAILED TO ATTACH | Semaphore set identifier 0x0 has not been initialized. Consider cleaning this semaphore if this warning occurs multiple times for this semaphore across all applications on this machine.
WARNING [0x01012101,0x06200367,0x9571CBF0:0x000100C2|DP ANNOUNCE|SEND] RTIOsapiSharedMemorySemMutex_attach_os:FAILED TO ATTACH | Semaphore set identifier 0x0 has not been initialized. Consider cleaning this semaphore if this warning occurs multiple times for this semaphore across all applications on this machine.
(...)
```

By default in Kubernetes the PID namespace is not shared among containers in the same pod:
```kubectl explain pod.spec.shareProcessNamespace
DESCRIPTION:
    Share a single process namespace between all of the containers in a pod.
    When this is set containers will be able to view and signal processes from
    other containers in the same pod, and the first process in each container
    will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be
    set. Optional: Default to false.
```
Thus we need to set `shareProcessNamespace: true` for pods where containers communicate over shmem.
