### PR TITLE
Restore detailed example documentation

### DIFF
--- a/external_to_pod_gw/README.md
+++ b/external_to_pod_gw/README.md
@@ -1,19 +1,71 @@
-## Communications Between External Applications and Pods Using a Gateway
+## Communicaitons Between External Applications and Pods Within a Kubernetes Cluster Using a Gateway
 
-This example uses RTI Routing Service and Real-time WAN Transport to expose an internal DDS subscriber through a NodePort service. Before deployment, set the appropriate `PUBLIC_IP` and `PUBLIC_PORT` values in `rtiroutingservice.yaml`.
+### Problem
 
-## Deploy
+Explosing DDS applications outside a Kubernetes cluster introduces complexities due to the internal virtual network. Each pod in a k8s cluster is allocated a virtual IP address, which is inherently inaccessible from outside the cluster. This complicates the direct communication required by external applications aiming to exchange data with applications operating within the cluster.
 
-Run these commands from the repository root:
+### Solution
 
-```bash
-kubectl create namespace rti-examples
-kubectl create configmap rti-license --from-file=rti_license.dat -n rti-examples
-kubectl create configmap routingservice-rwt \
-  --from-file=external_to_pod_gw/USER_ROUTING_SERVICE.xml -n rti-examples
-kubectl apply -f external_to_pod_gw/
-```
+To establish communication between internal and external DDS applications, we employ the **RTI Routing Service (RTI RS)** combined with **Real-time WAN Transport** as a gateway. A NodePort service is configured to expose the RTI Routing Service on a static port at each node's IP address, enabling external applications to interact with applicaitons within the cluster.
 
-Get the assigned NodePort with `kubectl get service -n rti-examples`. Run the external publisher with the `RWT_Demo::RWT_Profile` from `rwt_participant.xml`, using the node address and assigned port.
+#### Required Components:
 
-All resources are deployed to the fixed `rti-examples` namespace.
+* **DDS Publisher and Subscriber**: These are example applications that demonstrate the data exchange.
+* **Routing Service**: Acts as a gateway within the k8s cluster, forwarding data from the external DDS Publisher to the internal DDS Subscriber.
+* **NodePort Service**: Created to expose the Routing Service on each node’s IP at a specified static port (e.g., Port 30007 as shown in the example diagram). External participants can access the Routing Service by using the address format NodeIP:NodePort (e.g., NODE2_IP:30007).
+
+![Exposing DDS Applications with Real-time WAN Transport](routingservice_rwt.png)
+
+### Required Docker Images
+- [RTI Routing Service](https://hub.docker.com/repository/docker/rticom/routing-service)
+- [RTI Cloud Discovery Service](https://hub.docker.com/repository/docker/rticom/cloud-discovery-service)
+- [RTI DDS Ping](https://hub.docker.com/repository/docker/rticom/dds-ping)
+
+### Steps
+
+#### 1. Create a ConfigMap for RTI License.
+`$ kubectl create configmap rti-license --from-file rti_license.dat -n rti-examples`
+
+This command creates a ConfigMap to store the RTI License, required for running RTI Cloud Discovery Service and RTI Routing Service in the evaluation package.
+
+#### 2. Create a Deployment and a ClusterIP Service for Cloud Discovery Service.
+`$ kubectl create -f rticlouddiscoveryservice.yaml`
+
+This command creates a Deployment and a Service for RTI Cloud Discovery Service, which is used for discovery between the internal DDS Subscriber and RTI Routing Service. 
+
+#### 3. Create a ConfigMap for the Routing Service XML configuration file
+`$ kubectl create configmap routingservice-rwt --from-file=USER_ROUTING_SERVICE.xml -n rti-examples`
+
+This command stores the Routing Service XML configuration file (USER_ROUTING_SERVICE.xml) as a ConfigMap, which can be updated as needed. 
+
+#### 4. Create a NodePort service for Routing Service
+`$ kubectl create -f rtiroutingservice_nodeport.yaml `
+
+This step creates a NodePort service for the RTI Routing Service to make the RTI Routing Service accessible from external applications.
+
+#### 5. Create a StatefulSet for Routing Service. 
+`$ kubectl get service -n rti-examples`
+
+Use this command to get the external port assigned by Kubernetes (NodePorts are in the 30000-32767 range by default). 
+
+`$ kubectl get nodes -o wide`
+
+Use this command to get IP addresses of nodes (For PUBLIC_IP, you can use an IP address of externally accessible nodes).
+
+**NOTE: Update the values for PUBLIC_IP (with one of IP addresses of nodes) and PUBLIC_PORT (with the assigned node port) as necessary in rtiroutingservice.yaml.**
+
+`$ kubectl create -f rtiroutingservice.yaml`
+
+Finally, running this command creates a StatefulSet for RTI Routing Service. 
+
+#### 6. Create a Deployment for a RTI DDS Ping subscriber
+`$ kubectl create -f rtiddsping_cds_sub.yaml`
+
+This command deploys the internal RTI DDS Ping Subscriber, which uses Cloud Discovery Service for discovering the RTI Routing Service within the cluster.
+
+#### 7. Run the external publisher (outside the cluster). 
+**NOTE: Adjust the initial_peer setting (using PUBLIC_IP:PUBLIC_PORT) in rwt_participant.xml.**
+
+`$ rtiddsping -qosFile rwt_participant.xml -qosProfile RWT_Demo::RWT_Profile -publisher -domainId 100`
+
+With these configurations, all necessary components should now be operational within the Kubernetes cluster. Execute the command above to run the external DDS Publisher application.

--- a/external_to_pod_lb_gw/README.md
+++ b/external_to_pod_lb_gw/README.md
@@ -1,19 +1,69 @@
-## Communications Between External Applications and Pods Using a Load-Balanced Gateway
+## Communications Between External Applications And Pods Within a Kubernetes Cluster Using a Network Load-Balanced Gateway
 
-This example uses an RTI Routing Service deployment behind a LoadBalancer service to expose DDS traffic over Real-time WAN Transport. It requires a Kubernetes environment with LoadBalancer support. Before deployment, set `PUBLIC_IP` in `rtiroutingservice.yaml` to an external address assigned by the load balancer.
+### Problem
 
-## Deploy
+You need to ensure scalability and fault tolerance for Routing Services to accommodate varying loads and ensure high availability. 
 
-Run these commands from the repository root:
+### Solution
 
-```bash
-kubectl create namespace rti-examples
-kubectl create configmap rti-license --from-file=rti_license.dat -n rti-examples
-kubectl create configmap routingservice-rwt \
-  --from-file=external_to_pod_lb_gw/USER_ROUTING_SERVICE.xml -n rti-examples
-kubectl apply -f external_to_pod_lb_gw/
-```
+To address this challenge, deploying RTI Routing Services using a Kubernetes **Deployment** and **LoadBalancer service** facilitates scalability and high availability. A LoadBalancer Service, integrating with an external Network Load Balancer (NLB) provided by AWS, is utilized to expose the traffic of the Routing Services. This configuration allows the LoadBalancer Service, in conjunction with the external NLB, to distribute incoming traffic evenly from outside the cluster to multiple Routing Service pods, effectively scaling up the service in response to demand while maintaining high availability.
 
-Use `kubectl get services -n rti-examples` to obtain the external endpoint. Configure the external publisher from `rwt_participant.xml` with that endpoint.
+**NOTE: This example only works with AWS NLB with cross-zone load balancing.**
 
-All resources are deployed to the fixed `rti-examples` namespace.
+![Load Balancing Routing Services with Real-time WAN Transport](routingservice_rwt_lb.png)
+
+### Required Docker Images
+- [RTI Routing Service](https://hub.docker.com/repository/docker/rticom/routing-service)
+- [RTI Cloud Discovery Service](https://hub.docker.com/repository/docker/rticom/cloud-discovery-service)
+- [RTI DDS Ping](https://hub.docker.com/repository/docker/rticom/dds-ping)
+
+### Steps
+
+#### 1. Create a ConfigMap for RTI License.
+`$ kubectl create configmap rti-license --from-file rti_license.dat -n rti-examples`
+
+This command creates a ConfigMap to store the RTI License, required for running RTI Cloud Discovery Service and RTI Routing Service in the evaluation package.
+
+#### 2. Create a Deployment and a ClusterIP Service for Cloud Discovery Service.
+`$ kubectl create -f rticlouddiscoveryservice.yaml`
+
+This command creates a Deployment and a Service for RTI Cloud Discovery Service, which is used for discovery between the internal DDS Subscriber and RTI Routing Service. 
+
+#### 3. Create a ConfigMap for the Routing Service XML configuration file
+`$ kubectl create configmap routingservice-rwt --from-file=USER_ROUTING_SERVICE.xml -n rti-examples`
+
+This command stores the Routing Service XML configuration file (USER_ROUTING_SERVICE.xml) as a ConfigMap, which can be updated as needed. 
+
+#### 4. Create a LoadBalancer Service for Routing Service. 
+`$ kubectl create -f rtiroutingservice_loadbalancer.yaml`
+
+This step creates a LoadBalancer service for the RTI Routing Service to make the RTI Routing Service accessible and load balanced from external applications.
+
+#### 5. Create a Deployment for the Routing Service. 
+
+`$ kubectl get services rti-routingservice -n rti-examples`
+
+Use this command to get the external DNS name (e.g., a709579e8e4db40248531847d6245779-0bc4e2a058d739ab.elb.us-east-2.amazonaws.com) assigned by AWS Network Load Balancer.
+
+Then, you run the following command to get an public IP address from the DNS name. 
+
+`$ nslookup a709579e8e4db40248531847d6245779-0bc4e2a058d739ab.elb.us-east-2.amazonaws.com`
+
+**NOTE: Update the values for PUBLIC_IP with one of the external addresses in rtiroutingservice.yaml.**
+
+`$ kubectl create -f rtiroutingservice.yaml`
+
+Finally, running this command creates a Deployment for RTI Routing Service. 
+
+#### 6. Create a Deployment for a RTI DDS Ping subscriber
+`$ kubectl create -f rtiddsping_cds_sub.yaml`
+
+This command deploys the internal RTI DDS Ping Subscriber, which uses Cloud Discovery Service for discovering the RTI Routing Service within the cluster.
+
+#### 7. Run the external publisher (outside the cluster). You should update the public IP address and port in this file.
+
+**NOTE: Adjust the initial_peer setting (using PUBLIC_IP:PUBLIC_PORT) in rwt_participant.xml.**
+
+`$ rtiddsping -qosFile rwt_participant.xml -qosProfile RWT_Demo::RWT_Profile -publisher -domainId 100`
+
+With these configurations, all necessary components should now be operational within the Kubernetes cluster. Execute the command above to run the external DDS Publisher application.

--- a/intra_pod_shmem/README.md
+++ b/intra_pod_shmem/README.md
@@ -1,15 +1,35 @@
 ## Communications over Shared Memory
 
-This example runs DDS Ping containers in one pod so they communicate over shared memory, while a separate subscriber uses UDP through Cloud Discovery Service.
+### Problem
+You want to make Connext containers communicate over shared memory.
 
-## Deploy
+### Solution
+Containers in a pod share the same IPC namespace, which means they can communicate with each other using standard inter-process communications such as SystemV semaphores or POSIX shared memory. If containers are in the same pod and are also configured to share the same process namespace, Connext containers with a version above 6.0 can communicate over shared memory with the default settings. (Please see [this](https://community.rti.com/kb/communicate-between-two-docker-containers-using-rti-connext-dds-and-shared-memory) if you use an older version.) A Connext container can use both shared memory transport for container-to-container communications (in the same pod) and UDP transport for pod-to-pod communications.
 
-Run these commands from the repository root:
+![Container Communications over Shared Memory](ddsping_shmem.png)
 
-```bash
-kubectl create namespace rti-examples
-kubectl create configmap rti-license --from-file=rti_license.dat -n rti-examples
-kubectl apply -f intra_pod_shmem/
-```
+### Required Docker Images
+- [RTI Cloud Discovery Service](https://hub.docker.com/repository/docker/rticom/cloud-discovery-service)
+- [RTI DDS Ping](https://hub.docker.com/repository/docker/rticom/dds-ping)
 
-All resources are deployed to the fixed `rti-examples` namespace.
+### Steps
+
+#### Create a ConfigMap for RTI License.
+`$ kubectl create configmap rti-license --from-file rti_license.dat -n rti-examples`
+
+This command creates a ConfigMap to store the RTI License, which is necessary for running RTI CDS in the evaluation package.
+The manifests deploy to the `rti-examples` namespace.
+
+#### Create a Deployment and a Service for Cloud Discovery Service.
+`$ kubectl create -f rticlouddiscoveryservice.yaml`
+
+Use this command to create a Deployment and a Service for the RTI CDS.
+
+#### Create a publisher and subscriber over shared memory transport.
+`$ kubectl create -f rtiddsping_shmem.yaml`
+
+This command deploys the RTI DDS Ping Publisher and Subscriber that communicate over shared memory transport.
+
+#### Deploy a subscriber over UDP transport.
+`$ kubectl create -f rtiddsping_sub.yaml`
+This command deploys the RTI DDS Ping Subscriber that communicates using UDP transport.

--- a/pod_to_pod_multicast_disc/README.md
+++ b/pod_to_pod_multicast_disc/README.md
@@ -1,14 +1,32 @@
 ## Communications Between Pods Inside a Kubernetes Cluster via Multicast Discovery
 
-This example uses DDS built-in multicast discovery between publisher and subscriber pods. It requires a Kubernetes CNI that supports multicast traffic.
+### Problem
 
-## Deploy
+You want to establish communications between Connext DDS applications running in different pods within a Kubernetes cluster. 
 
-Run these commands from the repository root. This example needs no ConfigMap:
+### Solution
 
-```bash
-kubectl create namespace rti-examples
-kubectl apply -f pod_to_pod_multicast_disc/
-```
+When running Connext DDS applications in a Kubernetes cluster, especially when leveraging a Container Network Interface (CNI) plugin supporting multicast (e.g., WeaveNet and Cilium), you can use automatic builtin discovery between DDS application pods. This built-in discovery of DDS mechanism eliminates the need for a Kubernetes service for DDS discovery. DDS application pods can autonomously discover and establish connections with each other through topics, abstracting IP-based communications. This enables DDS application pods to communicate seamlessly within the cluster without relying on a Kubernetes service.
 
-All resources are deployed to the fixed `rti-examples` namespace.
+![Pod-to-pod Communications Inside a Cluster](ddsping.png)
+
+### Required Docker Images
+- [RTI DDS Ping](https://hub.docker.com/repository/docker/rticom/dds-ping)
+
+### Steps
+Follow these steps to enable pod-to-pod communication for DDS applications within your Kubernetes cluster:
+The manifests deploy to the `rti-examples` namespace.
+
+#### Create a Deployment for DDS ping publisher.
+`$ kubectl create -f rtiddsping_pub.yaml`
+
+This command deploys the RTI DDS Ping Publisher within your Kubernetes cluster.
+
+#### Create a Deployment for DDS ping subscriber.
+`$ kubectl create -f rtiddsping_sub.yaml`
+
+This command creates a Deployment for the RTI DDS Ping Subscriber. This subscriber can now communicate with the RTI DDS Ping publisher.
+
+These steps ensure that your DDS applications can communicate seamlessly within the Kubernetes cluster, leveraging DDS's built-in discovery mechanism. With this setup, you don't need to create an additional Kubernetes service for DDS discovery, simplifying your cluster configuration and communication setup.
+
+Remember to adapt the configurations and images according to your specific use case, and ensure you have a Kubernetes cluster with a compatible container networking interface (CNI) plugin that supports multicast for DDS discovery.

--- a/pod_to_pod_unicast_disc/README.md
+++ b/pod_to_pod_unicast_disc/README.md
@@ -1,31 +1,85 @@
-## Communications Between Pods with Unicast Discovery
+## Scenario 1 - Communications Between Pods Inside a Kubernetes Cluster via Unicast Discovery
 
-These examples use RTI Cloud Discovery Service (CDS) for DDS discovery when the Kubernetes CNI does not support multicast. The single-CDS and redundant CDS scenarios are separate because they reuse deployment names.
+### Problem
 
-## Deploy the single-CDS scenario
+You want to enable DDS discovery within a Kubernetes cluster without relying on multicast. This is especially relevant as many Container Network Interface (CNI) plugins in Kubernetes do not support multicast.
 
-Run these commands from the repository root:
+### Solution
 
-```bash
-kubectl create namespace rti-examples
-kubectl create configmap rti-license --from-file=rti_license.dat -n rti-examples
-kubectl apply -f pod_to_pod_unicast_disc/rticlouddiscoveryservice.yaml
-kubectl apply -f pod_to_pod_unicast_disc/rtiddsping_cds_pub.yaml
-kubectl apply -f pod_to_pod_unicast_disc/rtiddsping_cds_sub.yaml
-```
+To address the multicast limitation in Kubernetes, you can leverage **RTI Cloud Discovery Service (CDS)**. CDS provides a solution for DDS discovery in environments where multicast is not supported. To use CDS, you need to add the IP address or DNS name and port number of the CDS to the initial peer lists of your Connext DDS applications. To get a stable IP address or DNS name within Kubernetes, you can employ a Cluster IP Service. Cluster IP is the default type of Kubernetes Service and exposes a pod on a stable internal IP in the cluster. With this, the pod for RTI CDS is reachable by DDS applications via a stable IP address or DNS name (e.g. rti-clouddiscovery:7400).
 
-## Deploy the redundant CDS (HA) scenario
+**NOTE: RTI CDS currently lacks support for synchronization across multiple instances, so this example only works with a single CDS instance per service.**
 
-Use a separate namespace or remove the single-CDS scenario first because both scenarios use the same publisher and subscriber deployment names:
+![Discovery without Multicast](ddsping_cds.png)
 
-```bash
-kubectl create namespace rti-examples
-kubectl create configmap rti-license --from-file=rti_license.dat -n rti-examples
-kubectl apply -f pod_to_pod_unicast_disc/rticlouddiscoveryservice_ha.yaml
-kubectl apply -f pod_to_pod_unicast_disc/rtiddsping_cds_pub_ha.yaml
-kubectl apply -f pod_to_pod_unicast_disc/rtiddsping_cds_sub_ha.yaml
-```
+### Required Docker Images
+- [RTI Cloud Discovery Service](https://hub.docker.com/repository/docker/rticom/cloud-discovery-service)
+- [RTI DDS Ping](https://hub.docker.com/repository/docker/rticom/dds-ping)
 
-The HA scenario creates a StatefulSet and headless service. Participants discover its CDS instances through their stable DNS names.
+### Steps
+Follow these steps to enable DDS discovery without multicast within your Kubernetes cluster:
+The manifests deploy to the `rti-examples` namespace.
 
-All resources are deployed to the fixed `rti-examples` namespace.
+#### Create a ConfigMap for RTI License.
+`$ kubectl create configmap rti-license --from-file rti_license.dat -n rti-examples`
+
+This command creates a ConfigMap to store the RTI License, which is necessary for running the RTI CDS in the evaluation package.
+
+#### Create a Deployment and a Service for Cloud Discovery Service.
+`$ kubectl create -f rticlouddiscoveryservice.yaml`
+
+Deploy the RTI CDS using this command, which creats both a Deployment and a Service to create and expose the RTI CDS within the cluster. 
+
+#### Create a Deployment for DDS ping publisher.
+`$ kubectl create -f rtiddsping_cds_pub.yaml`
+
+This command deploys the RTI DDS Ping Publisher, which uses the CDS for discovery within the Kubernetes cluster.
+
+#### Create a Deployment for DDS ping subscriber.
+`$ kubectl create -f rtiddsping_cds_sub.yaml`
+
+Deploy the RTI DDS Ping Subscriber using this command. It leverages the CDS for DDS discovery, allowing communication with the RTI DDS Ping Publisher.
+
+These steps ensure that your DDS applications can discover each other within the Kubernetes cluster even in environments that do not support multicast. By integrating the RTI Cloud Discovery Service and using a Cluster IP Service, you can manage discovery processes with multicast limitations in some Kubernetes environments.
+
+## Scenario 2 - Communications Between Pods Inside a Kubernetes Cluster Using Redundant RTI Cloud Discovery Services
+
+### Problem
+
+Achieving high availability for the Cloud Discovery Service (CDS) within a Kubernetes environment is essential for ensuring continuous operation, especially in scenarios where service downtime is not acceptable.
+
+### Solution
+
+To achieve high availability of the RTI Cloud Discovery Service, deploying it via a **StatefulSet** combined with a **Headless Service** is recommended. StatefulSet ensures orderly and unique deployment of service instances, while the Headless Service provides a stable network identity. This setup creates a reliable domain name allowing Connext application pods to discover each other by adding the DNS names of the CDS services (e.g., rti-cds-0.rti-cds-hs.rti-examples.svc.cluster.local:7400) to their discovery peer lists. This configuration ensures that application pods can still communicate effectively even if one of the CDS instances fails.
+
+![Discovery without Multicast](cds_replicated.png)
+
+### Required Docker Images
+- [RTI Cloud Discovery Service](https://hub.docker.com/repository/docker/rticom/cloud-discovery-service)
+- [RTI DDS Ping](https://hub.docker.com/repository/docker/rticom/dds-ping)
+
+### Steps
+
+#### Create a ConfigMap for RTI License.
+`$ kubectl create configmap rti-license --from-file rti_license.dat -n rti-examples`
+
+This command creates a ConfigMap to store the RTI License, which is necessary for running RTI CDS in the evaluation package.
+
+#### Create a StatefulSet and Headless Services for Cloud Discovery Service.
+`$ kubectl create -f rticlouddiscoveryservice_ha.yaml`
+
+This command deploys the RTI CDS using a StatefulSet alongside a Headless Service, setting up redundant CDS instances for enhanced availability. Each instance is accessible via a unique endpoint, such as rti-cds-0.
+
+#### Create a Deployment for DDS ping publisher.
+`$ kubectl create -f rtiddsping_cds_pub_ha.yaml`
+
+This command deploys the RTI DDS Ping Publisher, which can now use redundant CDSes for discovery within your Kubernetes cluster.
+
+#### Create a Deployment for DDS ping subscriber.
+`$ kubectl create -f rtiddsping_cds_sub_ha.yaml`
+
+This command creates a Deployment for the RTI DDS Ping Subscriber. It can also leverage redundant CDSes for discovery, allowing communication with the RTI DDS Ping Publisher.
+
+Adjust the configurations and image names according to your specific DDS application and environment requirements.
+
+Ensure that you have the necessary licenses and permissions for using RTI CDS.


### PR DESCRIPTION
## Summary
- restore the detailed guides in every example directory
- retain the `rti-examples` namespace guidance in prerequisite commands
- update the HA CDS DNS example for `rti-examples`

## Validation
- checked namespace-aware ConfigMap and HA DNS documentation
- verified the focused diff has no whitespace errors